### PR TITLE
Fix testDedicatedHostPrototypeDedicatedHostByZone and 9 other tests

### DIFF
--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/DedicatedHostPrototypeDedicatedHostByZoneTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/DedicatedHostPrototypeDedicatedHostByZoneTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.DedicatedHostGroupPrototypeDedicatedHostByZoneContext;
 import com.ibm.cloud.is.vpc.v1.model.DedicatedHostProfileIdentityByName;
 import com.ibm.cloud.is.vpc.v1.model.DedicatedHostPrototypeDedicatedHostByZone;
@@ -80,7 +81,7 @@ public class DedicatedHostPrototypeDedicatedHostByZoneTest {
     assertEquals(dedicatedHostPrototypeDedicatedHostByZoneModelNew.name(), "my-host");
     assertEquals(dedicatedHostPrototypeDedicatedHostByZoneModelNew.profile().toString(), dedicatedHostProfileIdentityModel.toString());
     assertEquals(dedicatedHostPrototypeDedicatedHostByZoneModelNew.resourceGroup().toString(), resourceGroupIdentityModel.toString());
-    assertEquals(dedicatedHostPrototypeDedicatedHostByZoneModelNew.group().toString(), dedicatedHostGroupPrototypeDedicatedHostByZoneContextModel.toString());
+    assertEquals(JsonParser.parseString(dedicatedHostPrototypeDedicatedHostByZoneModelNew.group().toString()), JsonParser.parseString(dedicatedHostGroupPrototypeDedicatedHostByZoneContextModel.toString()));
     assertEquals(dedicatedHostPrototypeDedicatedHostByZoneModelNew.zone().toString(), zoneIdentityModel.toString());
   }
 

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager;
 import com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeById;
 import com.ibm.cloud.is.vpc.v1.utils.TestUtilities;
@@ -56,7 +57,7 @@ public class InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSp
     assertTrue(instanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerModelNew instanceof InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager);
     assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerModelNew.name(), "my-instance-group-manager-action");
     assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerModelNew.cronSpec(), "*/5 1,2,3 * * *");
-    assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerModelNew.manager().toString(), instanceGroupManagerScheduledActionManagerPrototypeModel.toString());
+    assertEquals(JsonParser.parseString(instanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerModelNew.manager().toString()), JsonParser.parseString(instanceGroupManagerScheduledActionManagerPrototypeModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager;
 import com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeById;
 import com.ibm.cloud.is.vpc.v1.utils.TestUtilities;
@@ -57,7 +58,7 @@ public class InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtB
     assertTrue(instanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerModelNew instanceof InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager);
     assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerModelNew.name(), "my-instance-group-manager-action");
     assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerModelNew.runAt(), DateUtils.parseAsDateTime("2019-01-01T12:00:00.000Z"));
-    assertEquals(instanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerModelNew.manager().toString(), instanceGroupManagerScheduledActionManagerPrototypeModel.toString());
+    assertEquals(JsonParser.parseString(instanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerModelNew.manager().toString()), JsonParser.parseString(instanceGroupManagerScheduledActionManagerPrototypeModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceByImageTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceByImageTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.ImageIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
@@ -195,7 +196,7 @@ public class InstancePrototypeInstanceByImageTest {
     assertEquals(instancePrototypeInstanceByImageModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instancePrototypeInstanceByImageModelNew.userData(), "testString");
     assertEquals(instancePrototypeInstanceByImageModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instancePrototypeInstanceByImageModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByImageContextModel.toString());
+    assertEquals(JsonParser.parseString(instancePrototypeInstanceByImageModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByImageContextModel.toString()));
     assertEquals(instancePrototypeInstanceByImageModelNew.image().toString(), imageIdentityModel.toString());
     assertEquals(instancePrototypeInstanceByImageModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instancePrototypeInstanceByImageModelNew.zone().toString(), zoneIdentityModel.toString());

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceBySourceTemplateTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceBySourceTemplateTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.ImageIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
@@ -203,7 +204,7 @@ public class InstancePrototypeInstanceBySourceTemplateTest {
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.userData(), "testString");
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByImageContextModel.toString());
+    assertEquals(JsonParser.parseString(instancePrototypeInstanceBySourceTemplateModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByImageContextModel.toString()));
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.image().toString(), imageIdentityModel.toString());
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instancePrototypeInstanceBySourceTemplateModelNew.sourceTemplate().toString(), instanceTemplateIdentityModel.toString());

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceByVolumeTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstancePrototypeInstanceByVolumeTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstanceProfileIdentityByName;
@@ -195,7 +196,7 @@ public class InstancePrototypeInstanceByVolumeTest {
     assertEquals(instancePrototypeInstanceByVolumeModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instancePrototypeInstanceByVolumeModelNew.userData(), "testString");
     assertEquals(instancePrototypeInstanceByVolumeModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instancePrototypeInstanceByVolumeModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByVolumeContextModel.toString());
+    assertEquals(JsonParser.parseString(instancePrototypeInstanceByVolumeModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByVolumeContextModel.toString()));
     assertEquals(instancePrototypeInstanceByVolumeModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instancePrototypeInstanceByVolumeModelNew.zone().toString(), zoneIdentityModel.toString());
   }

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceByImageTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceByImageTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.ImageIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
@@ -195,7 +196,7 @@ public class InstanceTemplatePrototypeInstanceByImageTest {
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.userData(), "testString");
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByImageContextModel.toString());
+    assertEquals(JsonParser.parseString(instanceTemplatePrototypeInstanceByImageModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByImageContextModel.toString()));
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.image().toString(), imageIdentityModel.toString());
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instanceTemplatePrototypeInstanceByImageModelNew.zone().toString(), zoneIdentityModel.toString());

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceBySourceTemplateTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceBySourceTemplateTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.ImageIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
@@ -203,7 +204,7 @@ public class InstanceTemplatePrototypeInstanceBySourceTemplateTest {
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.userData(), "testString");
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByImageContextModel.toString());
+    assertEquals(JsonParser.parseString(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByImageContextModel.toString()));
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.image().toString(), imageIdentityModel.toString());
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instanceTemplatePrototypeInstanceBySourceTemplateModelNew.sourceTemplate().toString(), instanceTemplateIdentityModel.toString());

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/VolumeAttachmentPrototypeInstanceByImageContextTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/VolumeAttachmentPrototypeInstanceByImageContextTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.VolumeAttachmentPrototypeInstanceByImageContext;
 import com.ibm.cloud.is.vpc.v1.model.VolumeProfileIdentityByName;
@@ -72,7 +73,7 @@ public class VolumeAttachmentPrototypeInstanceByImageContextTest {
     assertTrue(volumeAttachmentPrototypeInstanceByImageContextModelNew instanceof VolumeAttachmentPrototypeInstanceByImageContext);
     assertEquals(volumeAttachmentPrototypeInstanceByImageContextModelNew.deleteVolumeOnInstanceDelete(), Boolean.valueOf(true));
     assertEquals(volumeAttachmentPrototypeInstanceByImageContextModelNew.name(), "my-volume-attachment");
-    assertEquals(volumeAttachmentPrototypeInstanceByImageContextModelNew.volume().toString(), volumePrototypeInstanceByImageContextModel.toString());
+    assertEquals(JsonParser.parseString(volumeAttachmentPrototypeInstanceByImageContextModelNew.volume().toString()), JsonParser.parseString(volumePrototypeInstanceByImageContextModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/VolumeAttachmentPrototypeInstanceByVolumeContextTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/VolumeAttachmentPrototypeInstanceByVolumeContextTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.SnapshotIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.VolumeAttachmentPrototypeInstanceByVolumeContext;
@@ -80,7 +81,7 @@ public class VolumeAttachmentPrototypeInstanceByVolumeContextTest {
     assertTrue(volumeAttachmentPrototypeInstanceByVolumeContextModelNew instanceof VolumeAttachmentPrototypeInstanceByVolumeContext);
     assertEquals(volumeAttachmentPrototypeInstanceByVolumeContextModelNew.deleteVolumeOnInstanceDelete(), Boolean.valueOf(false));
     assertEquals(volumeAttachmentPrototypeInstanceByVolumeContextModelNew.name(), "my-volume-attachment");
-    assertEquals(volumeAttachmentPrototypeInstanceByVolumeContextModelNew.volume().toString(), volumeAttachmentVolumePrototypeInstanceByVolumeContextModel.toString());
+    assertEquals(JsonParser.parseString(volumeAttachmentPrototypeInstanceByVolumeContextModelNew.volume().toString()), JsonParser.parseString(volumeAttachmentVolumePrototypeInstanceByVolumeContextModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## The Problem

The tests

```
com.ibm.cloud.is.vpc.v1.model.DedicatedHostPrototypeDedicatedHostByZoneTest.testDedicatedHostPrototypeDedicatedHostByZone
com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerTest.testInstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager
com.ibm.cloud.is.vpc.v1.model.InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerTest.testInstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager
com.ibm.cloud.is.vpc.v1.model.InstancePrototypeInstanceByImageTest.testInstancePrototypeInstanceByImage
com.ibm.cloud.is.vpc.v1.model.InstancePrototypeInstanceBySourceTemplateTest.testInstancePrototypeInstanceBySourceTemplate
com.ibm.cloud.is.vpc.v1.model.InstancePrototypeInstanceByVolumeTest.testInstancePrototypeInstanceByVolume
com.ibm.cloud.is.vpc.v1.model.InstanceTemplatePrototypeInstanceByImageTest.testInstanceTemplatePrototypeInstanceByImage
com.ibm.cloud.is.vpc.v1.model.InstanceTemplatePrototypeInstanceBySourceTemplateTest.testInstanceTemplatePrototypeInstanceBySourceTemplate
com.ibm.cloud.is.vpc.v1.model.VolumeAttachmentPrototypeInstanceByImageContextTest.testVolumeAttachmentPrototypeInstanceByImageContext
com.ibm.cloud.is.vpc.v1.model.VolumeAttachmentPrototypeInstanceByVolumeContextTest.testVolumeAttachmentPrototypeInstanceByVolumeContext
```

are flaky as was discovered through the plugin [NonDex](https://github.com/TestingResearchIllinois/NonDex). Here are the full steps to reproduce this issue:

```
git clone https://github.com/IBM/vpc-java-sdk && cd vpc-java-sdk
export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
mvn clean install -pl modules/vpc -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=DedicatedHostPrototypeDedicatedHostByZoneTest#testDedicatedHostPrototypeDedicatedHostByZone
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManagerTest#testInstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManagerTest#testInstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstancePrototypeInstanceByImageTest#testInstancePrototypeInstanceByImage
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstancePrototypeInstanceBySourceTemplateTest#testInstancePrototypeInstanceBySourceTemplate
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstancePrototypeInstanceByVolumeTest#testInstancePrototypeInstanceByVolume
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstanceTemplatePrototypeInstanceByImageTest#testInstanceTemplatePrototypeInstanceByImage
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstanceTemplatePrototypeInstanceBySourceTemplateTest#testInstanceTemplatePrototypeInstanceBySourceTemplate
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=VolumeAttachmentPrototypeInstanceByImageContextTest#testVolumeAttachmentPrototypeInstanceByImageContext
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=VolumeAttachmentPrototypeInstanceByVolumeContextTest#testVolumeAttachmentPrototypeInstanceByVolumeContext
```

The build will fail.

The current implementation compares two serializations with each other in each one of these tests. However, it would be safer to directly compare the objects themselves to avoid any issues where serialization strings are different but representing the same object. NonDex shuffles the ordering of fields so that the serialization strings differ, causing the tests to fail without having any real issues.

## The Fix

It's a very simple fix, instead of comparing serializations, `JsonParser` from GSON is used to compare their deserialized forms to make sure that the test will not fail with the plugin because a field in the serialization string is in a different ordering from another that is constructed from the same object.

After the fix, running the previous series of commands will no longer make the build fail. It will make sure that no false alarm goes off because of such reasons.

Please do give some feedbacks on whether you think this way of fixing it is feasible. Thanks!